### PR TITLE
Say when a mesh write is past the merge

### DIFF
--- a/.claude/skills/icc-patch/SKILL.md
+++ b/.claude/skills/icc-patch/SKILL.md
@@ -88,7 +88,11 @@ other side, comma separated. Pipes says what a side writes and reads.
   at once, one gets it and the other fails. Nothing here looks at it;
   remove deletes it with the rest. What the write left on the wire, as
   Tee and Merge say, is still moving when it returns; the lock does not
-  wait for that. A ring has no fittings and nothing to lock.
+  wait for that. On a mesh it is past the merge once its end is back at
+  the writer's own read end: the tee puts each chunk on every outlet
+  before it reads the next, as Tee says, so nothing written after it
+  can come before it at any seat. A ring has no fittings and nothing to
+  lock.
 - Through fittings, a seat that never reads stalls every writer once its
   end fills. Read every end, or keep the payload inside one. Tee's and
   Merge's SKILL.md have the numbers.


### PR DESCRIPTION
Closes #1.

One sentence in the lock bullet of `.claude/skills/icc-patch/SKILL.md`. It said the lock does not wait for what the write left on the wire, and stopped there. It now adds that on a mesh the write is past the merge once its end is back at the writer's own read end, because the tee puts each chunk on every outlet before it reads the next, as Tee says, so nothing written after it can come before it at any seat. Moot's say relies on that; now Patch states it.

Point 1 of the issue, a lock owner, is a non-issue as noted on the issue: Moot uses the lock as documented and never tries to tell a stale lock from a live one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqckVSSLQ9AqdQEu51a2eP

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqckVSSLQ9AqdQEu51a2eP)_