### PR TITLE
star: a pipe from each seat to the parent, nothing between the seats

### DIFF
--- a/.claude/skills/icc-patch/SKILL.md
+++ b/.claude/skills/icc-patch/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: icc-patch
 description: >-
-  Patch icc-pipes pipes, icc-tee tees and icc-merge merges into a ring or
-  a mesh over N seats, with or without a parent in on it, and hand every
-  seat a map of the ends it holds. The bay makes nothing but the map.
-  What goes down the cables, and who sits where, is the caller's
-  business.
+  Patch icc-pipes pipes, icc-tee tees and icc-merge merges into a star,
+  a ring or a mesh over N seats, with or without a parent in on it, and
+  hand every seat a map of the ends it holds. The bay makes nothing but
+  the map. What goes down the cables, and who sits where, is the
+  caller's business.
 ---
 
 # icc-patch
@@ -35,6 +35,8 @@ is missing, create makes nothing.
 
 ## Shapes
 
+    star     seat i shares a pipe with seat p, i on side 0, p on side 1.
+             Nothing joins the seats to each other
     ring     seat i shares a pipe with seat i+1, i on side 0, i+1 on
              side 1, around the end back to 0
     mesh     a merge and a tee in the middle. Every seat writes one end
@@ -47,8 +49,9 @@ is missing, create makes nothing.
 
 N counts seats other than p. Fewer seats, fewer cables, by the shape
 alone: a fitting with one end on a side is no fitting. mesh 2 is one
-pipe, and so is mesh-p 1, one seat with its parent. ring 2 is mesh 2.
-ring 1 is one pipe with seat 0 on both ends. mesh 1 is no pipe.
+pipe, and so is mesh-p 1, one seat with its parent, and so is star 1.
+ring 2 is mesh 2. ring 1 is one pipe with seat 0 on both ends. mesh 1 is
+no pipe.
 
 ## The map
 
@@ -60,7 +63,9 @@ Seat SEAT holds side SIDE of the pipe at DIR. PEERS is the seats on the
 other side, comma separated. Pipes says what a side writes and reads.
 
 - On a pipe two seats share, what SEAT writes there reaches PEERS and
-  what it reads there came from PEERS. Both ways.
+  what it reads there came from PEERS. Both ways. On a star every end is
+  one of these, so p holds one end per seat and knows which seat it is
+  talking to.
 - Through fittings, an end goes one way. A write end, side 0, sends to
   PEERS and reads nothing. A read end, side 1, receives from PEERS and
   sends nowhere. Tee's and Merge's SKILL.md say why.
@@ -91,8 +96,8 @@ other side, comma separated. Pipes says what a side writes and reads.
   wait for that. On a mesh it is past the merge once its end is back at
   the writer's own read end: the tee puts each chunk on every outlet
   before it reads the next, as Tee says, so nothing written after it
-  can come before it at any seat. A ring has no fittings and nothing to
-  lock.
+  can come before it at any seat. A star and a ring have no fittings and
+  nothing to lock.
 - Through fittings, a seat that never reads stalls every writer once its
   end fills. Read every end, or keep the payload inside one. Tee's and
   Merge's SKILL.md have the numbers.

--- a/.claude/skills/icc-patch/scripts/create
+++ b/.claude/skills/icc-patch/scripts/create
@@ -11,8 +11,8 @@
 set -eu
 [ $# -ge 2 ] || { echo "usage: create SHAPE N [LANES]" >&2; exit 1; }
 shape=$1; n=$2; lanes=${3:-2}
-case $shape in ring|mesh|ring-p|mesh-p) ;;
-  *) echo "shape is ring, mesh, ring-p or mesh-p" >&2; exit 1;; esac
+case $shape in star|ring|mesh|ring-p|mesh-p) ;;
+  *) echo "shape is star, ring, mesh, ring-p or mesh-p" >&2; exit 1;; esac
 [ "$n" -ge 1 ] 2>/dev/null || { echo "seats must be 1 or more" >&2; exit 1; }
 top=$(cd "$(dirname "$0")/../../../.." && pwd)
 P=$(cd "${ICC_PIPES:-$top/../ICC-Pipes}/.claude/skills/icc-pipes/scripts" && pwd)
@@ -30,6 +30,7 @@ cable() {  # cable A B: one pipe, seat A on side 0, seat B on side 1
 }
 all=0; i=1; while [ "$i" -lt "$n" ]; do all="$all $i"; i=$((i + 1)); done
 case $shape in
+  star) for i in $all; do cable "$i" p; done ;;
   ring)
     case $n in 1) cable 0 0 ;; 2) cable 0 1 ;;
       *) for i in $all; do cable "$i" $(( (i + 1) % n )); done ;; esac ;;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,9 @@ which seat.
   nothing between the seats. A mesh is a merge and a tee in the middle.
   A ring is a pipe from each seat to the next; with the parent in, each
   hop is a tee, the parent reads one merge of them all and writes one
-  tee to them all. Five shapes. Fewer seats means fewer cables, by the shape alone: two
-  seats on a mesh is one pipe, one seat with its parent is one pipe.
+  tee to them all. Five shapes. Fewer seats means fewer cables, by the
+  shape alone: two seats on a mesh is one pipe, one seat with its parent
+  is one pipe.
 - The skill covers creating, listing, and removing patches. Using one is
   reading the map and holding the ends it names. Nothing else.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,13 +28,13 @@ which seat.
 - A **patch**: the pipes, tees and merges one shape needs over N seats,
   made by their own skills, and a **map** saying which end each seat
   holds and which seats are on the other side of it.
-- The shapes are ring and mesh, each with or without the parent in on
-  it. A mesh is a merge and a tee in the middle. A ring is a pipe from
-  each seat to the next; with the parent in, each hop is a tee, the
-  parent reads one merge of them all and writes one tee to them all.
-  Four shapes. Fewer seats means
-  fewer cables, by the shape alone: two seats on a mesh is one pipe, one
-  seat with its parent is one pipe.
+- The shapes are star, and ring and mesh each with or without the
+  parent in on it. A star is a pipe from each seat to the parent and
+  nothing between the seats. A mesh is a merge and a tee in the middle.
+  A ring is a pipe from each seat to the next; with the parent in, each
+  hop is a tee, the parent reads one merge of them all and writes one
+  tee to them all. Five shapes. Fewer seats means fewer cables, by the shape alone: two
+  seats on a mesh is one pipe, one seat with its parent is one pipe.
 - The skill covers creating, listing, and removing patches. Using one is
   reading the map and holding the ends it names. Nothing else.
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,12 +18,24 @@ end() { awk -v s="$1" -v i="$2" -v p="$3" \
   '$1==s && $2==i && ("," $4 ",") ~ ("," p ",") {print $3}' "$x/patch"; }
 made() { [ "$(grep -c "$1" "$x/made")" -eq "$2" ]; }
 "$S/create" 2>/dev/null && exit 1
-"$S/create" star 3 2>/dev/null && exit 1
+"$S/create" bus 3 2>/dev/null && exit 1
 "$S/create" ring 0 2>/dev/null && exit 1
 "$S/create" ring 3 3 2>/dev/null && exit 1
 [ -z "$("$S/list")" ]
 head -c 150000 /dev/urandom > in
 trap 'for x in /tmp/icc-patch-*; do "$S/remove" "$x" 2>/dev/null || :; done; rm -f in out' EXIT
+x=$("$S/create" star 3 6)
+"$S/list" | grep -qx "$x up star 3 6"
+made icc-pipes 3; made icc-tee 0; made icc-merge 0
+[ "$(grep -c '^p ' "$x/patch")" -eq 3 ]
+"$F/write" "$(end 1 0 p)" 0 < in
+timeout 5 "$F/read" "$(end p 1 1)" 1 > out; cmp in out
+"$F/write" "$(end p 1 2)" 1 < in
+timeout 5 "$F/read" "$(end 2 0 p)" 0 > out; cmp in out
+printf 'me' > "$(end 0 0 p)/0"; [ "$(timeout 1 cat "$(end p 1 0)/0")" = me ]
+[ -z "$(end 0 0 2)" ]; [ -z "$(end 0 1 p)" ]
+"$S/remove" "$x"; [ ! -d "$x" ]
+x=$("$S/create" star 1); made icc-pipes 1; "$S/remove" "$x"
 x=$("$S/create" ring 3 6)
 "$S/list" | grep -qx "$x up ring 3 6"
 made icc-pipes 3; made icc-tee 0; made icc-merge 0


### PR DESCRIPTION
The shape everyone already runs was the one shape the bay could not make. This adds it.

- `create star N`: N pipes, seat i on side 0 and p on side 1. No fittings, nothing to lock. star 1 is one pipe, like mesh-p 1.
- The map is unchanged. p holds one end per seat, so it knows which seat it is talking to.
- SKILL.md and CLAUDE.md name five shapes instead of four.
- tests/run.sh makes a star over three seats, checks three pipes and no fittings, pushes a Frames payload from a seat to p and back, sends plain bytes, checks no seat has an end to another seat, removes it, and checks star 1 is one pipe. The rejected-name check uses "bus" now.

Harness run with Pipes, Tee, Merge and Frames cloned beside the repo: ok before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VffngGkr9mmmVyFg9BPcxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VffngGkr9mmmVyFg9BPcxm)_